### PR TITLE
Add EMBEDDED_CLI_SERIAL_XLATE option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-g -Wall -Wextra -Werror -pipe -I. -std=c99
+CFLAGS=-g -Wall -Wextra -Werror -pipe -I. --std=c99
 CLANG_FORMAT=clang-format
 CLANG?=clang
 

--- a/embedded_cli.c
+++ b/embedded_cli.c
@@ -24,8 +24,13 @@ static void cli_puts(struct embedded_cli *cli, const char *s)
 
 static void cli_putchar(struct embedded_cli *cli, char ch)
 {
-    if (cli->putchar)
+    if (cli->putchar) {
+#if EMBEDDED_CLI_SERIAL_XLATE
+        if (ch == '\n')
+            cli->putchar(cli->cb_data, '\r');
+#endif
         cli->putchar(cli->cb_data, ch);
+    }
 }
 
 static void embedded_cli_reset_line(struct embedded_cli *cli)
@@ -365,6 +370,11 @@ bool embedded_cli_insert_char(struct embedded_cli *cli, char ch)
                 else
                     embedded_cli_insert_default_char(cli, ch);
                 break;
+#if EMBEDDED_CLI_SERIAL_XLATE
+            case '\r':
+                ch = '\n';  // So cli->done will exit
+#endif
+                // fallthrough
             case '\n':
                 cli_putchar(cli, '\n');
                 break;

--- a/embedded_cli.h
+++ b/embedded_cli.h
@@ -32,6 +32,14 @@
 #define EMBEDDED_CLI_MAX_PROMPT_LEN 10
 #endif
 
+#ifndef EMBEDDED_CLI_SERIAL_XLATE
+/**
+ * Translate CR -> NL on input and output CR NL on output. This allows "natural" processing when
+ * using a serial terminal.
+ */
+#define EMBEDDED_CLI_SERIAL_XLATE 1
+#endif
+
 /**
  * This is the structure which defines the current state of the CLI
  * NOTE: Although this structure is exposed here, it is not recommended


### PR DESCRIPTION
When this option is set then CR will be considered (along with NL)
as ending a command, and NLs will be translated to CR NLs.
This makes things work seamlessly with serial terminals.