### PR TITLE
Fix array bounds issue when too many arguments passed.

### DIFF
--- a/embedded_cli.c
+++ b/embedded_cli.c
@@ -448,6 +448,9 @@ int embedded_cli_argc(struct embedded_cli *cli, char ***argv)
         }
 
         if (!in_arg) {
+            if (pos >= EMBEDDED_CLI_MAX_ARGC) {
+                break;
+            }
             cli->argv[pos] = &cli->buffer[i];
             pos++;
             in_arg = true;
@@ -470,6 +473,12 @@ int embedded_cli_argc(struct embedded_cli *cli, char ***argv)
             i--;
         }
     }
+    // Traditionally, there is a NULL entry at argv[argc].
+    if (pos >= EMBEDDED_CLI_MAX_ARGC) {
+        pos--;
+    }
+    cli->argv[pos] = NULL;
+
     *argv = cli->argv;
     return pos;
 }

--- a/tests/embedded_cli_test.c
+++ b/tests/embedded_cli_test.c
@@ -201,6 +201,20 @@ static void test_quotes(void)
     TEST_ASSERT(strcmp(argv[5], "\"escape\"") == 0);
 }
 
+static void test_too_many_args(void)
+{
+    struct embedded_cli cli;
+    char **argv;
+    embedded_cli_init(&cli, NULL, NULL, NULL);
+    test_insert_line(&cli, "a b c d e f g h i j k l m n o p q r s\n");
+    TEST_ASSERT(embedded_cli_argc(&cli, &argv) == EMBEDDED_CLI_MAX_ARGC - 1);
+    TEST_ASSERT(strcmp(argv[0], "a") == 0);
+    TEST_ASSERT(strcmp(argv[1], "b") == 0);
+    TEST_ASSERT(strcmp(argv[13], "n") == 0);
+    TEST_ASSERT(strcmp(argv[14], "o") == 0);
+    TEST_ASSERT(argv[15] == NULL);
+}
+
 TEST_LIST = {
     {"simple", test_simple},
     {"argc", test_argc},
@@ -215,5 +229,6 @@ TEST_LIST = {
     {"multiple", test_multiple},
     {"echo", test_echo},
     {"quotes", test_quotes},
+    {"too_many_args", test_too_many_args},
     {NULL, NULL},
 };


### PR DESCRIPTION
The current implementation will happily write to cli->argv beyond EMBEDDED_CLI_MAX_ARGC.

Normally, argv[argc] contains a null pointer. See: https://en.cppreference.com/w/cpp/language/main_function

I'd be happy to have the "store a NULL at argv[argc]" behaviout be a compile time option.